### PR TITLE
Chore/ci fixes

### DIFF
--- a/.github/workflows/Update_Docker_Images.yml
+++ b/.github/workflows/Update_Docker_Images.yml
@@ -2,7 +2,7 @@ name: Update Docker Images for Plane on Release
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
 
 jobs:
   build_push_backend:

--- a/.github/workflows/Update_Docker_Images.yml
+++ b/.github/workflows/Update_Docker_Images.yml
@@ -3,6 +3,11 @@ name: Update Docker Images for Plane on Release
 on:
   release:
     types: [released, prereleased]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the Images'
+        required: true
 
 jobs:
   build_push_backend:

--- a/docker-compose-hub.yml
+++ b/docker-compose-hub.yml
@@ -36,7 +36,7 @@ x-api-and-worker-env:
 services:
         plane-web:
                 container_name: planefrontend
-                image: makeplane/plane-frontend:latest
+                image: henit0885/plane-frontend:latest
                 restart: always
                 command: /usr/local/bin/start.sh web/server.js web
                 env_file:
@@ -58,7 +58,7 @@ services:
 
         plane-deploy:
                 container_name: planedeploy
-                image: makeplane/plane-deploy:latest
+                image: henit0885/plane-deploy:latest
                 restart: always
                 command: /usr/local/bin/start.sh space/server.js space
                 env_file:
@@ -72,9 +72,11 @@ services:
 
         plane-api:
                 container_name: planebackend
-                image: makeplane/plane-backend:latest
+                image: henit0885/plane-backend:latest
                 restart: always
                 command: ./bin/takeoff
+                ports:
+                        - 8000:8000
                 env_file:
                         - .env
                 environment:
@@ -85,7 +87,7 @@ services:
 
         plane-worker:
                 container_name: planebgworker
-                image: makeplane/plane-worker:latest
+                image: henit0885/plane-backend:latest
                 restart: always
                 command: ./bin/worker
                 env_file:
@@ -99,7 +101,7 @@ services:
 
         plane-beat-worker:
                 container_name: planebeatworker
-                image: makeplane/plane-worker:latest
+                image: henit0885/plane-backend:latest
                 restart: always
                 command: ./bin/beat
                 env_file:
@@ -159,7 +161,7 @@ services:
         # Comment this if you already have a reverse proxy running
         plane-proxy:
                 container_name: planeproxy
-                image: makeplane/plane-proxy:latest
+                image: henit0885/plane-proxy:latest
                 ports:
                         - ${NGINX_PORT}:80
                 env_file:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "packages/*"
   ],
   "scripts": {
-    "prepare": "husky install",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "start": "turbo run start",


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR introduces several updates to the CI/CD workflow and Docker image references. The workflow now supports pre-releases and manual triggers, allowing for more flexibility in the deployment process. Docker image references in the docker-compose-hub.yml file have been updated to point to a new repository. Additionally, the 'prepare' script has been removed from package.json.

___
## PR Main Files Walkthrough:
`.github/workflows/Update_Docker_Images.yml`: Added support for pre-releases and manual triggers in the workflow. Manual triggers require a tag input.
`docker-compose-hub.yml`: Updated Docker image references to point to a new repository. Also, exposed port 8000 for the 'plane-api' service.
`package.json`: Removed the 'prepare' script which was previously used for Husky setup.
