### PR TITLE
chore: added update param for release

### DIFF
--- a/.github/workflows/Update_Docker_Images.yml
+++ b/.github/workflows/Update_Docker_Images.yml
@@ -2,7 +2,7 @@ name: Update Docker Images for Plane on Release
 
 on:
   release:
-    types: [released, prereleased]
+    types: [released, prereleased, edited]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR updates the GitHub Actions workflow for updating Docker images. It now triggers not only on release and pre-release events, but also when a release is edited.

___
## PR Main Files Walkthrough:
`.github/workflows/Update_Docker_Images.yml`: The trigger types for the 'release' event in the workflow have been updated to include 'edited', allowing the workflow to run when a release is edited.
